### PR TITLE
Fix CI Error

### DIFF
--- a/src/libxgboost.jl
+++ b/src/libxgboost.jl
@@ -1,4 +1,4 @@
-include("../deps/deps.jl")
+include(Pkg.dir("XGBoost", "deps", "build.jl"))
 
 
 if build_version == "master"


### PR DESCRIPTION
`deps.jl` is `build.jl`, but instead of using a relative path, use `Pkg.dir`